### PR TITLE
Hf cli test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: ci
 on:
   pull_request:
   push:
-    branches:
-      - main
 
 jobs:
   lint:

--- a/test/system/050-pull.bats
+++ b/test/system/050-pull.bats
@@ -82,6 +82,31 @@ load setup_suite
     run_ramalama list
     is "$output" ".*TinyLlama/TinyLlama-1.1B-Chat-v1.0" "image was actually pulled locally"
     run_ramalama rm huggingface://TinyLlama/TinyLlama-1.1B-Chat-v1.0
+
+    run_ramalama pull hf://ggml-org/SmolVLM-256M-Instruct-GGUF
+    run_ramalama list
+    is "$output" ".*ggml-org/SmolVLM-256M-Instruct-GGUF" "image was actually pulled locally"
+    run_ramalama rm huggingface://ggml-org/SmolVLM-256M-Instruct-GGUF
+
+    run_ramalama pull hf://ggml-org/SmolVLM-256M-Instruct-GGUF:Q8_0
+    run_ramalama list
+    is "$output" ".*ggml-org/SmolVLM-256M-Instruct-GGUF:Q8_0" "image was actually pulled locally"
+    run_ramalama rm huggingface://ggml-org/SmolVLM-256M-Instruct-GGUF:Q8_0
+}
+
+# bats test_tags=distro-integration
+@test "ramalama pull huggingface tag multiple references" {
+    run_ramalama pull hf://ggml-org/SmolVLM-256M-Instruct-GGUF
+    run_ramalama list
+    is "$output" ".*ggml-org/SmolVLM-256M-Instruct-GGUF" "image was actually pulled locally"
+    run_ramalama --debug pull hf://ggml-org/SmolVLM-256M-Instruct-GGUF:Q8_0
+    is "$output" ".*Using cached blob" "cached blob was used"
+    run_ramalama list
+    is "$output" ".*ggml-org/SmolVLM-256M-Instruct-GGUF:Q8_0" "reference was created to existing image"
+    run_ramalama --debug rm huggingface://ggml-org/SmolVLM-256M-Instruct-GGUF
+    is "$output" ".*Not removing snapshot" "snapshot with remaining reference was not deleted"
+    run_ramalama --debug rm huggingface://ggml-org/SmolVLM-256M-Instruct-GGUF:Q8_0
+    is "$output" ".*Snapshot removed" "snapshot with no remaining references was deleted"
 }
 
 # bats test_tags=distro-integration


### PR DESCRIPTION
## Summary by Sourcery

Improve Hugging Face and ModelScope backends with richer API metadata support, safetensors repository handling, stronger error taxonomy, reference-counted storage cleanup, and expanded tests

New Features:
- Support downloading Hugging Face safetensors repositories by detecting repo type and fetching all non-config .safetensors files with checksums
- Add fetch_repo_info helper to retrieve repository metadata from the Hugging Face API
- Implement reference-counted blob and snapshot removal in the model store to avoid deleting shared artifacts

Bug Fixes:
- Avoid redundant downloads by skipping existing snapshot blobs and making symlink creation idempotent
- Improve error handling for invalid or missing metadata with custom HFInvalidRepoMetadataError
- Handle JSON decoding failures and model-not-found scenarios with dedicated HFModelNotFoundError
- Fix KeyError usage in CLI to use the new RamaLamaError base exception

Enhancements:
- Introduce specialized HF error hierarchy (HFError, HFUnknownRepoTypeError, etc.) across Hugging Face and ModelScope backends
- Generalize checksum fetching via fetch_data_from_api_base and streamline API interactions
- Extend CLI download arguments to allow specifying individual files
- Enhance pull fallback logic to retry via CLI when URL fetch fails and add debug logging on failures

CI:
- Update GitHub Actions workflow to remove branch restrictions and run CI on all pushes

Tests:
- Add bats tests covering safetensors pulls, multiple tag references, cache reuse, and reference-counted removal behavior